### PR TITLE
[CCP-122] Some changes to allow for a Heroku App to be deployed

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm start

--- a/README.md
+++ b/README.md
@@ -22,3 +22,25 @@ Launch the server by typing:
 ```bash
 npm run dev
 ```
+
+## Infrastructure
+
+AMA-bot Heroku PAAS to host and resource the application. Its run under a Pipeline: 
+
+https://dashboard.heroku.com/pipelines/e878c65d-db2d-4e7d-8640-0b3a0b3b4109
+
+Which if needed anyone can be added as a contributor to gain access to deploy branches to develop and test on.
+
+Currently the application only has one distribution step operational called 'staging'. This runs the server
+application as a Heroku 'dyno' using the `Procfile` in the projects root to define behavior. This application is 
+located at:
+
+https://cc-ama-bot-dev.herokuapp.com/
+
+This is the domain needed to be configured in the Event Subscription of the Slack App Configuration.
+
+This `staging` pipeline step automatically deploys the `develop` branch of the repo from github and can manually
+be triggered to deploy any branch by a contributor at the bottom of the applications deploy menu on Heroku.
+
+The `staging` application also has a postgres database 'add on' which can be accessed by the `dyno` process using the 
+environment variable `DATABASE_URL`. It is currently using Postgres 10.6.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/commoncode/ama-bot/issues"
   },
   "homepage": "https://github.com/commoncode/ama-bot#readme",
+  "engines": {
+    "node": "10.13"
+  },
   "dependencies": {
     "body-parser": "^1.18.3",
     "botkit": "^0.7.0",


### PR DESCRIPTION
- pinned the node version in package.json
- added a Procfile, Heroku actually assumes `npm start` is used but I thought just to be clear we have this, additionally if it changes in the future its already there.
- added some information about where to find the Heruko application and light deets about how it is currently setup.