### PR TITLE
[CCP-126] Botkit Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # dependencies
 /node_modules
 
+# local DB
+.db_bot
+
 # misc
 .DS_Store
 .env

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 release: knex migrate:latest
-web: npm start
+web: npm run staging

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Install dependencies:
 
 ```bash
 npm install
-npm run dev
 ```
 
 Add `.env` file in the project root directory.
@@ -38,6 +37,8 @@ located at:
 https://cc-ama-bot-dev.herokuapp.com/
 
 This is the domain needed to be configured in the Event Subscription of the Slack App Configuration.
+Once Slack App configuration done, go to https://cc-ama-bot-dev.herokuapp.com/login and click Authorize button to
+install the App.
 
 This `staging` pipeline step automatically deploys the `develop` branch of the repo from github and can manually
 be triggered to deploy any branch by a contributor at the bottom of the applications deploy menu on Heroku.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ located at:
 https://cc-ama-bot-dev.herokuapp.com/
 
 This is the domain needed to be configured in the Event Subscription of the Slack App Configuration.
-Once Slack App configuration done, go to https://cc-ama-bot-dev.herokuapp.com/login and click Authorize button to
-install the App.
 
 This `staging` pipeline step automatically deploys the `develop` branch of the repo from github and can manually
 be triggered to deploy any branch by a contributor at the bottom of the applications deploy menu on Heroku.
@@ -61,6 +59,15 @@ To create a new migration, run `knex migration:make create_MYTABLE` from the roo
 Run `knex migrate:latest` from the terminal to run all migrations that haven't yet been run. 
 
 As defined in the Heroku Procfile, all latest migrations should be run before each release. 
+
+## Botkit
+
+This project uses [Botkit](https://botkit.ai/docs/readme-slack.html) to connect server to Slack bot, 
+go to http://server-domain/login, and click **Authorize** button, backend server will be connected to slack 
+if there is no error message in console, this process authorizes the server and stores workspace information on server.
+
+Only need to run this process for first time set up or deploy this project, or if local storage is removed 
+(e.g. `.db_bot` on root directry is deleted).
 
 ## CircleCI
 

--- a/bot.js
+++ b/bot.js
@@ -1,0 +1,46 @@
+const dotenv = require('dotenv');
+const botkit = require('botkit');
+const server = require('./server');
+
+dotenv.load();
+
+if (
+  !process.env.SLACK_CLIENT_ID || 
+  !process.env.SLACK_CLIENT_SECRET || 
+  !process.env.SLACK_CLIENT_SIGNING_SECRET ||
+  !process.env.PORT
+) {
+  process.exit(1);
+}
+
+const botOptions = {
+  clientId: process.env.SLACK_CLIENT_ID,
+  clientSecret: process.env.SLACK_CLIENT_SECRET,
+  clientSigningSecret: process.env.SLACK_CLIENT_SIGNING_SECRET,
+  scopes: ['bot'],
+}
+
+if (process.env.DB_URL) {
+  // TODO: config postgres storage.
+  // botOptions.storage = postgresStorage;
+} else {
+  // Store user data in a simple JSON format.
+  botOptions.json_file_store = '.db_bot/'; 
+}
+
+// Create the Botkit controller, which controls all instances of the bot.
+const slackController = botkit.slackbot(botOptions);
+
+slackController.startTicking();
+
+// Set up express server.
+server(slackController);
+
+require(__dirname + '/components/userRegistration.js')(slackController);
+require(__dirname + '/components/onBoarding.js')(slackController);
+
+// Load in skills.
+const normalizedPath = require("path").join(__dirname, '/skills');
+require("fs").readdirSync(normalizedPath).forEach(file => {
+  require("./skills/" + file)(slackController);
+});

--- a/bot.js
+++ b/bot.js
@@ -1,12 +1,14 @@
 const dotenv = require('dotenv');
 const botkit = require('botkit');
 const server = require('./server');
+const userRegistration = require('./components/userRegistration');
+const onBoarding = require('./components/onBoarding');
 
 dotenv.load();
 
 if (
-  !process.env.SLACK_CLIENT_ID || 
-  !process.env.SLACK_CLIENT_SECRET || 
+  !process.env.SLACK_CLIENT_ID ||
+  !process.env.SLACK_CLIENT_SECRET ||
   !process.env.SLACK_CLIENT_SIGNING_SECRET ||
   !process.env.PORT
 ) {
@@ -18,14 +20,14 @@ const botOptions = {
   clientSecret: process.env.SLACK_CLIENT_SECRET,
   clientSigningSecret: process.env.SLACK_CLIENT_SIGNING_SECRET,
   scopes: ['bot'],
-}
+};
 
 if (process.env.DB_URL) {
   // TODO: config postgres storage.
   // botOptions.storage = postgresStorage;
 } else {
   // Store user data in a simple JSON format.
-  botOptions.json_file_store = '.db_bot/'; 
+  botOptions.json_file_store = '.db_bot/';
 }
 
 // Create the Botkit controller, which controls all instances of the bot.
@@ -36,11 +38,5 @@ slackController.startTicking();
 // Set up express server.
 server(slackController);
 
-require(__dirname + '/components/userRegistration.js')(slackController);
-require(__dirname + '/components/onBoarding.js')(slackController);
-
-// Load in skills.
-const normalizedPath = require("path").join(__dirname, '/skills');
-require("fs").readdirSync(normalizedPath).forEach(file => {
-  require("./skills/" + file)(slackController);
-});
+userRegistration(slackController);
+onBoarding(slackController);

--- a/components/onBoarding.js
+++ b/components/onBoarding.js
@@ -1,6 +1,6 @@
 const onBoardingHandler = (controller) => {
   controller.on('onboard', (bot) => {
-    bot.startPrivateConversation({ user: bot.config.createdBy }, (err,convo) => {
+    bot.startPrivateConversation({ user: bot.config.createdBy }, (err, convo) => {
 
       if (err) {
         console.error(err);
@@ -10,6 +10,6 @@ const onBoardingHandler = (controller) => {
       }
     });
   });
-}
+};
 
 module.exports = onBoardingHandler;

--- a/components/onBoarding.js
+++ b/components/onBoarding.js
@@ -1,0 +1,15 @@
+const onBoardingHandler = (controller) => {
+  controller.on('onboard', (bot) => {
+    bot.startPrivateConversation({ user: bot.config.createdBy }, (err,convo) => {
+
+      if (err) {
+        console.error(err);
+      } else {
+        convo.say('I am a bot that has just joined your team');
+        convo.say('You must now /invite me to a channel so that I can be of use!');
+      }
+    });
+  });
+}
+
+module.exports = onBoardingHandler;

--- a/components/userRegistration.js
+++ b/components/userRegistration.js
@@ -1,81 +1,81 @@
 const userRegistration = (slackController) => {
 
-	/* Handle event caused by a user logging in with oauth */
-	slackController.on('oauth:success', (payload) => {
+  /* Handle event caused by a user logging in with oauth */
+  slackController.on('oauth:success', (payload) => {
 
-		if (!payload.identity.team_id) {
-			console.error('Error: received an oauth response without a team id');
-		}
-		slackController.storage.teams.get(payload.identity.team_id, (err, team) => {
-			if (err) {
-				console.error('Error: could not load team from storage system: ', payload.identity.team_id, err);
-			}
+    if (!payload.identity.team_id) {
+      console.error('Error: received an oauth response without a team id');
+    }
+    slackController.storage.teams.get(payload.identity.team_id, (err, team) => {
+      if (err) {
+        console.error('Error: could not load team from storage system: ', payload.identity.team_id, err);
+      }
 
-			const isNewTeam = !team;
-			if (!team) {
-				team = {
-					id: payload.identity.team_id,
-					createdBy: payload.identity.user_id,
-					url: payload.identity.url,
-					name: payload.identity.team,
-				};
-			}
+      const isNewTeam = !team;
+      if (!team) {
+        team = {
+          id: payload.identity.team_id,
+          createdBy: payload.identity.user_id,
+          url: payload.identity.url,
+          name: payload.identity.team,
+        };
+      }
 
-			team.bot = {
-				token: payload.bot.bot_access_token,
-				user_id: payload.bot.bot_user_id,
-				createdBy: payload.identity.user_id,
-				app_token: payload.access_token,
-			};
+      team.bot = {
+        token: payload.bot.bot_access_token,
+        user_id: payload.bot.bot_user_id,
+        createdBy: payload.identity.user_id,
+        app_token: payload.access_token,
+      };
 
-			const testBot = slackController.spawn(team.bot);
+      const testBot = slackController.spawn(team.bot);
 
-			testBot.api.auth.test({}, (err, botAuth) => {
-				if (err) {
-					console.error('Error: could not authenticate bot user', err);
-				} else {
-					team.bot.name = botAuth.user;
+      testBot.api.auth.test({}, (err, botAuth) => {
+        if (err) {
+          console.error('Error: could not authenticate bot user', err);
+        } else {
+          team.bot.name = botAuth.user;
 
-					// add in info that is expected by Botkit
-					testBot.identity = botAuth;
+          // add in info that is expected by Botkit
+          testBot.identity = botAuth;
 
-					testBot.identity.id = botAuth.user_id;
-					testBot.identity.name = botAuth.user;
+          testBot.identity.id = botAuth.user_id;
+          testBot.identity.name = botAuth.user;
 
-					testBot.team_info = team;
+          testBot.team_info = team;
 
-					slackController.storage.teams.save(team, (err) => {
-						if (err) {
-							console.error('Error: could not save team record:', err);
-						} else {
-							if (isNewTeam) {
-								slackController.trigger('create_team', [testBot, team]);
-							} else {
-								slackController.trigger('update_team', [testBot, team]);
-							}
-						}
-					});
-				}
-			});
-		});
-	});
-
-
-	slackController.on('create_team', (bot, team) => {
-
-		// Trigger an event that will establish an RTM connection for this bot
-		slackController.trigger('rtm:start', [bot.config]);
-
-		// Trigger an event that will cause this team to receive onboarding messages
-		slackController.trigger('onboard', [bot, team]);
-	});
+          slackController.storage.teams.save(team, (err) => {
+            if (err) {
+              console.error('Error: could not save team record:', err);
+            } else {
+              if (isNewTeam) {
+                slackController.trigger('create_team', [testBot, team]);
+              } else {
+                slackController.trigger('update_team', [testBot, team]);
+              }
+            }
+          });
+        }
+      });
+    });
+  });
 
 
-	slackController.on('update_team', (bot) => {
+  slackController.on('create_team', (bot, team) => {
 
-		// Trigger an event that will establish an RTM connection for this bot
-		slackController.trigger('rtm:start', [bot]);
-	});
-}
+    // Trigger an event that will establish an RTM connection for this bot
+    slackController.trigger('rtm:start', [bot.config]);
+
+    // Trigger an event that will cause this team to receive onboarding messages
+    slackController.trigger('onboard', [bot, team]);
+  });
+
+
+  slackController.on('update_team', (bot) => {
+
+    // Trigger an event that will establish an RTM connection for this bot
+    slackController.trigger('rtm:start', [bot]);
+  });
+};
 
 module.exports = userRegistration;

--- a/components/userRegistration.js
+++ b/components/userRegistration.js
@@ -1,0 +1,81 @@
+const userRegistration = (slackController) => {
+
+	/* Handle event caused by a user logging in with oauth */
+	slackController.on('oauth:success', (payload) => {
+
+		if (!payload.identity.team_id) {
+			console.error('Error: received an oauth response without a team id');
+		}
+		slackController.storage.teams.get(payload.identity.team_id, (err, team) => {
+			if (err) {
+				console.error('Error: could not load team from storage system: ', payload.identity.team_id, err);
+			}
+
+			const isNewTeam = !team;
+			if (!team) {
+				team = {
+					id: payload.identity.team_id,
+					createdBy: payload.identity.user_id,
+					url: payload.identity.url,
+					name: payload.identity.team,
+				};
+			}
+
+			team.bot = {
+				token: payload.bot.bot_access_token,
+				user_id: payload.bot.bot_user_id,
+				createdBy: payload.identity.user_id,
+				app_token: payload.access_token,
+			};
+
+			const testBot = slackController.spawn(team.bot);
+
+			testBot.api.auth.test({}, (err, botAuth) => {
+				if (err) {
+					console.error('Error: could not authenticate bot user', err);
+				} else {
+					team.bot.name = botAuth.user;
+
+					// add in info that is expected by Botkit
+					testBot.identity = botAuth;
+
+					testBot.identity.id = botAuth.user_id;
+					testBot.identity.name = botAuth.user;
+
+					testBot.team_info = team;
+
+					slackController.storage.teams.save(team, (err) => {
+						if (err) {
+							console.error('Error: could not save team record:', err);
+						} else {
+							if (isNewTeam) {
+								slackController.trigger('create_team', [testBot, team]);
+							} else {
+								slackController.trigger('update_team', [testBot, team]);
+							}
+						}
+					});
+				}
+			});
+		});
+	});
+
+
+	slackController.on('create_team', (bot, team) => {
+
+		// Trigger an event that will establish an RTM connection for this bot
+		slackController.trigger('rtm:start', [bot.config]);
+
+		// Trigger an event that will cause this team to receive onboarding messages
+		slackController.trigger('onboard', [bot, team]);
+	});
+
+
+	slackController.on('update_team', (bot) => {
+
+		// Trigger an event that will establish an RTM connection for this bot
+		slackController.trigger('rtm:start', [bot]);
+	});
+}
+
+module.exports = userRegistration;

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "ama-bot",
   "version": "1.0.0",
   "description": "Backend server for Slack ama bot",
-  "main": "server.js",
+  "main": "bot.js",
   "scripts": {
-    "dev": "nodemon server.js",
+    "dev": "nodemon bot.js",
     "lint": "eslint .",
     "lint-fix": "eslint --fix ."
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "bot.js",
   "scripts": {
     "dev": "nodemon bot.js",
+    "staging": "node bot.js",
     "lint": "eslint .",
     "lint-fix": "eslint --fix ."
   },

--- a/routes/oauth.js
+++ b/routes/oauth.js
@@ -1,0 +1,35 @@
+const authRoutes = (webserver, slackController) => {
+  webserver.get('/login', (req, res) => {
+    res.redirect(slackController.getAuthorizeURL());
+  });
+
+  webserver.get('/oauth', (req) => {
+    const { code } = req.query;
+    const slackApi = slackController.spawn({})
+    const opts = {
+      client_id: slackController.config.clientId,
+      client_secret: slackController.config.clientSecret,
+      code: code,
+    };
+
+    slackApi.api.oauth.access(opts, (error, auth) => {
+      if (error) {
+        console.error('Error confirming oauth: ', error);
+      } else {
+        slackApi.api.auth.test({token: auth.access_token}, (error, identity) => {
+
+          if (error) {
+            console.error('Error confirming oauth: ', error);
+          }
+
+          auth.identity = identity;
+          slackController.trigger('oauth:success', [auth]);
+
+          // TODO: create a 'login_success.html' page and redirect to it.
+        });
+      }
+    });
+  });
+}
+
+module.exports = authRoutes;

--- a/routes/oauth.js
+++ b/routes/oauth.js
@@ -5,7 +5,7 @@ const authRoutes = (webserver, slackController) => {
 
   webserver.get('/oauth', (req) => {
     const { code } = req.query;
-    const slackApi = slackController.spawn({})
+    const slackApi = slackController.spawn({});
     const opts = {
       client_id: slackController.config.clientId,
       client_secret: slackController.config.clientSecret,
@@ -16,7 +16,7 @@ const authRoutes = (webserver, slackController) => {
       if (error) {
         console.error('Error confirming oauth: ', error);
       } else {
-        slackApi.api.auth.test({token: auth.access_token}, (error, identity) => {
+        slackApi.api.auth.test({ token: auth.access_token }, (error, identity) => {
 
           if (error) {
             console.error('Error confirming oauth: ', error);
@@ -30,6 +30,6 @@ const authRoutes = (webserver, slackController) => {
       }
     });
   });
-}
+};
 
 module.exports = authRoutes;

--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -1,0 +1,8 @@
+webhookRoutes = (webserver, slackController) => {
+  webserver.post('/slack/receive', (req, res) => {
+    res.status(200);
+    slackController.handleWebhookPayload(req, res);
+  });
+}
+
+module.exports = webhookRoutes;

--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -1,8 +1,8 @@
-webhookRoutes = (webserver, slackController) => {
+const webhookRoutes = (webserver, slackController) => {
   webserver.post('/slack/receive', (req, res) => {
     res.status(200);
     slackController.handleWebhookPayload(req, res);
   });
-}
+};
 
 module.exports = webhookRoutes;

--- a/server.js
+++ b/server.js
@@ -1,17 +1,26 @@
 const express = require('express');
 const bodyParser = require('body-parser');
-const dotenv = require('dotenv');
 
-dotenv.load();
+const server = (slackController) => {
+  const app = express();
+  const port = process.env.PORT;
+  
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({
+      extended: true
+  }));
+  
+  app.listen(port, function() {
+    console.log('Bot is listening on port ' + port);
+  });
 
-const app = express();
-const port = process.env.PORT;
+  // import all the pre-defined routes.
+  const normalizedPath = require("path").join(__dirname, "/routes");
+  require("fs").readdirSync(normalizedPath).forEach(file => {
+    require("./routes/" + file)(app, slackController);
+  });
 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({
-  extended: true,
-}));
+  slackController.webserver = app;
+}
 
-app.listen(port, function () {
-  console.log('Bot is listening on port ' + port);
-});
+module.exports = server;

--- a/server.js
+++ b/server.js
@@ -4,23 +4,23 @@ const bodyParser = require('body-parser');
 const server = (slackController) => {
   const app = express();
   const port = process.env.PORT;
-  
+
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({
-      extended: true
+    extended: true,
   }));
-  
-  app.listen(port, function() {
+
+  app.listen(port, function () {
     console.log('Bot is listening on port ' + port);
   });
 
   // import all the pre-defined routes.
-  const normalizedPath = require("path").join(__dirname, "/routes");
-  require("fs").readdirSync(normalizedPath).forEach(file => {
-    require("./routes/" + file)(app, slackController);
+  const normalizedPath = require('path').join(__dirname, '/routes');
+  require('fs').readdirSync(normalizedPath).forEach(file => {
+    require('./routes/' + file)(app, slackController);
   });
 
   slackController.webserver = app;
-}
+};
 
 module.exports = server;


### PR DESCRIPTION
### Task

[JIRA ticket](https://commoncode.atlassian.net/browse/CCP-126).

### Description

- Created `bot.js` to initialize a Slack App controller.
- Created `onBoardingHandler` to send a success message to user once the App installed in Slack workspace.
- Created `userRegistration` to store team(workspace) information once App installed.
- Created `oauth.js` to handle Slack App installation(connect the server to the App).
- Created `webhookRoutes` to receive Slack events.
- Changed entry file from `server.js` to `bot.js` to make the code cleaner, otherwise have to pass `slackController` and `app` into many different files which is messy.
- Most of code and file structure copied from [this repo](https://github.com/howdyai/botkit-starter-slack)