### PR TITLE
[CCP-98] Allow messages without teacher, make skills case insensitive

### DIFF
--- a/migrations/20190228115138_alter_skills_name_citext.js
+++ b/migrations/20190228115138_alter_skills_name_citext.js
@@ -1,0 +1,17 @@
+exports.up = function (knex, Promise) {
+  return Promise.all([
+    knex.schema
+      .raw('CREATE EXTENSION IF NOT EXISTS CITEXT')
+      .alterTable('skills', table => {
+        table.specificType('name', 'CITEXT').alter();
+      }),
+  ]);
+};
+
+exports.down = function (knex, Promise) {
+  return Promise.all([
+    knex.schema.alterTable('User', table => {
+      table.string('name').alter();
+    }),
+  ]);
+};


### PR DESCRIPTION
Includes extra change to skills table so that skill names are case insensitive (for ex. will prevent `React` and `react` from being added as separate skills)