### PR TITLE
[CCP-163] Slack Bot Broken after Reinstall

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,11 +1,9 @@
 const dotenv = require('dotenv');
 const botkit = require('botkit');
 const botkitStoragePostgres = require('botkit-storage-pg');
-const { transaction } = require('objection');
 const server = require('./server');
 const userRegistration = require('./components/userRegistration');
 const onBoarding = require('./components/onBoarding');
-const { BotkitTeam } = require('./models/schema');
 
 dotenv.load(); // Doesn't override already set environment variables
 
@@ -33,19 +31,13 @@ if (
   process.env.DB_USER &&
   process.env.DB_PASSWORD
 ) {
-  transaction(BotkitTeam.knex(), async trx => {
-    // `botkit-storage-pg` try to insert the same team record when the app is being reinstalled,
-    // so need to clear BotkitTeam table before install the app.
-    await BotkitTeam.query(trx).delete();
-
-    // Set up custom Postgres storage system to store workspaces, channels and users data.
-    botOptions.storage = botkitStoragePostgres({
-      host: process.env.DB_HOST,
-      port: process.env.DB_PORT,
-      database: process.env.DB_NAME,
-      user: process.env.DB_USER,
-      password: process.env.DB_PASSWORD,
-    });
+  // Set up custom Postgres storage system to store workspaces, channels and users data.
+  botOptions.storage = botkitStoragePostgres({
+    host: process.env.DB_HOST,
+    port: process.env.DB_PORT,
+    database: process.env.DB_NAME,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
   });
 } else {
   // Store workspaces, channels and users data in a simple JSON format.


### PR DESCRIPTION
Initially the app clears `botkit_team` table once deployed, the delete action can be delayed to after reinstallation is done, which means new team record could be deleted accidentally (not sure why, but probably be cause there is no `await` before `transaction`).
So moved delete action to before save new team, and it will delete team by id rather than remove all the data from `botkit_team` table