### PR TITLE
[CCP-177] Recognise bot as teacher

### DIFF
--- a/skills/hears.js
+++ b/skills/hears.js
@@ -151,7 +151,7 @@ const constructConfirmationMessage = (
 const extractMessageContents = async (bot, message) => {
   const asyncBot = genAsyncBot(bot);
 
-  const messageContent = message.text.replace(LEARNING_KEY, ' ');
+  const messageContent = message.event.text.replace(LEARNING_KEY, ' ');
   const skills = extractSkills(messageContent);
   const teachers = extractMentionedPeople(messageContent);
 


### PR DESCRIPTION
This is because Slack magically removes the bot name if mentioned at the start of a sentence. Simply using a different part of the message fixes this.