### PR TITLE
[WIP][CCP-194] Update Botkit

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,9 +1,10 @@
 const dotenv = require('dotenv');
-const botkit = require('botkit');
 const botkitStoragePostgres = require('botkit-storage-pg');
 const server = require('./server');
 const userRegistration = require('./components/userRegistration');
 const onBoarding = require('./components/onBoarding');
+const { Botkit } = require('botkit');
+const { SlackAdapter } = require('botbuilder-adapter-slack');
 
 dotenv.load(); // Doesn't override already set environment variables
 
@@ -11,11 +12,17 @@ if (
   !process.env.SLACK_CLIENT_ID ||
   !process.env.SLACK_CLIENT_SECRET ||
   !process.env.SLACK_CLIENT_SIGNING_SECRET ||
+  !process.env.SLACK_TOKEN ||
   !process.env.PORT
 ) {
   console.error('Empty or unset Environment Variables');
   process.exit(1);
 }
+
+const adapter = new SlackAdapter({
+  clientSigningSecret: process.env.SLACK_CLIENT_SIGNING_SECRET,
+  botToken: process.env.SLACK_TOKEN,
+});
 
 const botOptions = {
   clientId: process.env.SLACK_CLIENT_ID,
@@ -45,9 +52,7 @@ if (
 }
 
 // Create the Botkit controller, which controls all instances of the bot.
-const slackController = botkit.slackbot(botOptions);
-
-slackController.startTicking();
+const slackController = new Botkit({ adapter });
 
 // Set up express server.
 server(slackController);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,19 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@azure/ms-rest-js": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.2.6.tgz",
+      "integrity": "sha512-8cmDpxsQjVdveJwYKtNnkJorxEORLYJu9UHaUvLZA6yHExzDeISHAcSVWE0J05+VkJtqheVHF17M+2ro18Cdnw==",
+      "requires": {
+        "axios": "^0.18.0",
+        "form-data": "^2.3.2",
+        "tough-cookie": "^2.4.3",
+        "tslib": "^1.9.2",
+        "uuid": "^3.2.1",
+        "xml2js": "^0.4.19"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -718,10 +731,120 @@
         "@types/yargs": "^13.0.0"
       }
     },
-    "@types/async": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.4.2.tgz",
-      "integrity": "sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww=="
+    "@microsoft/recognizers-text": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text/-/recognizers-text-1.1.4.tgz",
+      "integrity": "sha512-hlSVXcaX5i8JcjuUJpVxmy2Z/GxvFXarF0KVySCFop57wNEnrLWMHe4I4DjP866G19VyIKRw+vPA32pkGhZgTg=="
+    },
+    "@microsoft/recognizers-text-choice": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-choice/-/recognizers-text-choice-1.1.4.tgz",
+      "integrity": "sha512-4CddwFe4RVhZeJgW65ocBrEdeukBMghK8pgI0K0Qy2eA5ysPZQpeZ7BGSDz5QMQei5LPY+QaAQ3CHU+ORHoO7A==",
+      "requires": {
+        "@microsoft/recognizers-text": "~1.1.4",
+        "grapheme-splitter": "^1.0.2"
+      }
+    },
+    "@microsoft/recognizers-text-date-time": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-date-time/-/recognizers-text-date-time-1.1.4.tgz",
+      "integrity": "sha512-leMnjN+KYNwNvRD5T4G0ORUzkjlek/BBZDvQIjAujtyrd/pkViUnuouWIPkFT/dbSOxXML8et54CSk2KfHiWIA==",
+      "requires": {
+        "@microsoft/recognizers-text": "~1.1.4",
+        "@microsoft/recognizers-text-number": "~1.1.4",
+        "@microsoft/recognizers-text-number-with-unit": "~1.1.4",
+        "lodash.isequal": "^4.5.0",
+        "lodash.tonumber": "^4.0.3"
+      }
+    },
+    "@microsoft/recognizers-text-number": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number/-/recognizers-text-number-1.1.4.tgz",
+      "integrity": "sha512-6EmlR+HR+eJBIX7sQby1vs6LJB64wxLowHaGpIU9OCXFvZ5Nb0QT8qh10rC40v3Mtrz4DpScXfSXr9tWkIO5MQ==",
+      "requires": {
+        "@microsoft/recognizers-text": "~1.1.4",
+        "bignumber.js": "^7.2.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.sortby": "^4.7.0",
+        "lodash.trimend": "^4.5.1"
+      }
+    },
+    "@microsoft/recognizers-text-number-with-unit": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number-with-unit/-/recognizers-text-number-with-unit-1.1.4.tgz",
+      "integrity": "sha512-zl+CfmfWK0x/x+iSgaBAevKTYO0F4+z7SYHAHztaaaGuX8FERw2jmUjSgVetm5KA3EveyCx0XYGU1mRNY8p7Eg==",
+      "requires": {
+        "@microsoft/recognizers-text": "~1.1.4",
+        "@microsoft/recognizers-text-number": "~1.1.4",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.last": "^3.0.0",
+        "lodash.max": "^4.0.1"
+      }
+    },
+    "@microsoft/recognizers-text-sequence": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-sequence/-/recognizers-text-sequence-1.1.4.tgz",
+      "integrity": "sha512-rb5j8/aE7HSOdIxaVfCGFrj0wWPpSq0CuykFg/A/iJNPP+FnAU71bgP5HexrwQcpCsDinauisX7u0DKIChrHRA==",
+      "requires": {
+        "@microsoft/recognizers-text": "~1.1.4",
+        "grapheme-splitter": "^1.0.2"
+      }
+    },
+    "@microsoft/recognizers-text-suite": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-suite/-/recognizers-text-suite-1.1.4.tgz",
+      "integrity": "sha512-hNIaR4M2G0nNeI9WZxt9C0KYh/1vhjeKzX5Ds8XDdT0pxF7zwCSo19WNcPjrVK6aCOeZTw/ULofsAjdu9gSkcA==",
+      "requires": {
+        "@microsoft/recognizers-text": "~1.1.4",
+        "@microsoft/recognizers-text-choice": "~1.1.4",
+        "@microsoft/recognizers-text-date-time": "~1.1.4",
+        "@microsoft/recognizers-text-number": "~1.1.4",
+        "@microsoft/recognizers-text-number-with-unit": "~1.1.4",
+        "@microsoft/recognizers-text-sequence": "~1.1.4"
+      }
+    },
+    "@slack/logger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-2.0.0.tgz",
+      "integrity": "sha512-OkIJpiU2fz6HOJujhlhfIGrc8hB4ibqtf7nnbJQDerG0BqwZCfmgtK5sWzZ0TkXVRBKD5MpLrTmCYyMxoMCgPw==",
+      "requires": {
+        "@types/node": ">=8.9.0"
+      }
+    },
+    "@slack/types": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-1.2.1.tgz",
+      "integrity": "sha512-NyGh7MibW+a0OHkwwOPlv63hC639dzQdkFy4dj0tl4sAdZR4OBaE/OhXixKhCzcT3kJsPXaQmvkUN7sqSf52iA=="
+    },
+    "@slack/web-api": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-5.4.0.tgz",
+      "integrity": "sha512-iCP7tED6pmGSWz0ZKjZPPpgSOjphmsgo+VMdqaLLnb8eRggsjswKJDruHBtoWENLVySq05qWFFeYtGG36Xv6RQ==",
+      "requires": {
+        "@slack/logger": ">=1.0.0 <3.0.0",
+        "@slack/types": "^1.2.1",
+        "@types/is-stream": "^1.1.0",
+        "@types/node": ">=8.9.0",
+        "@types/p-queue": "^2.3.2",
+        "axios": "^0.18.0",
+        "eventemitter3": "^3.1.0",
+        "form-data": "^2.5.0",
+        "is-stream": "^1.1.0",
+        "p-queue": "^2.4.2",
+        "p-retry": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "@types/babel__core": {
       "version": "7.1.3",
@@ -764,53 +887,12 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/body-parser": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
-      "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
-      "requires": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/caseless": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
-    },
-    "@types/connect": {
-      "version": "3.4.32",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
-      "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+    "@types/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/express": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
-      "integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
-      "requires": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.16.11",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.11.tgz",
-      "integrity": "sha512-K8d2M5t3tBQimkyaYTXxtHYyoJPUEhy2/omVRnTAKw5FEdT+Ft6lTaTOpoJdHeG+mIwQXXtqiTcYZ6IR8LTzjQ==",
-      "requires": {
-        "@types/node": "*",
-        "@types/range-parser": "*"
-      }
-    },
-    "@types/form-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.5.0.tgz",
-      "integrity": "sha512-23/wYiuckYYtFpL+4RPWiWmRQH2BjFuqCUi2+N3amB1a1Drv+i/byTrGvlLwRVLFNAZbwpbQ7JvTK+VCAPMbcg==",
-      "requires": {
-        "form-data": "*"
       }
     },
     "@types/istanbul-lib-coverage": {
@@ -846,73 +928,26 @@
         "@types/node": "*"
       }
     },
-    "@types/mime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
-    },
     "@types/node": {
-      "version": "9.6.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.55.tgz",
-      "integrity": "sha512-e/5tg8Ok0gSrN6pvHphnwTK0/CD9VPZrtZqpvvpEFAtfs+ZntusgGaWkf2lSEq1OFe2EDPeUMiMVpy4nZpJ4AQ=="
+      "version": "10.17.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.3.tgz",
+      "integrity": "sha512-QZ9CjUB3QoA3f2afw3utKlfRPhpmufB7jC2+oDhLWnXqoyx333fhKSQDLQu2EK7OE0a15X67eYiRAaJsHXrpMA=="
     },
-    "@types/range-parser": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+    "@types/p-queue": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/p-queue/-/p-queue-2.3.2.tgz",
+      "integrity": "sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ=="
     },
-    "@types/request": {
-      "version": "2.48.3",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.3.tgz",
-      "integrity": "sha512-3Wo2jNYwqgXcIz/rrq18AdOZUQB8cQ34CXZo+LUwPJNpvRAL86+Kc2wwI8mqpz9Cr1V+enIox5v+WZhy/p3h8w==",
-      "requires": {
-        "@types/caseless": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "form-data": "^2.5.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
-    "@types/serve-static": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
-      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
-      "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
-      }
-    },
-    "@types/sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-hkgzYF+qnIl8uTO8rmUSVSfQ8BIfMXC4yJAF4n8BE758YsKBZvFC4NumnAegj7KmylP0liEZNpb9RRGFMbFejA=="
+    "@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
-    },
-    "@types/tough-cookie": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
-    },
-    "@types/url-join": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-0.8.3.tgz",
-      "integrity": "sha512-bM7dzLHuCqDNlbeOxvo/KfweN3La4d9C1VFGCgefxiZXn0JcRtyGDwWCSUEO8RrMhnx/LGhDOXP8TTokM1grSA=="
     },
     "@types/yargs": {
       "version": "13.0.3",
@@ -929,484 +964,6 @@
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
       "dev": true
     },
-    "@webex/common": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.59.0.tgz",
-      "integrity": "sha512-HKL+U1Jia3Pg1XPV36NozBJe7yZIgAlaKfrnzt3i5JbQvtiLXCijvu5+o3plEuI/AFv2/04D67jql1DG8YXASw==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "backoff": "^2.5.0",
-        "core-decorators": "^0.20.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "urlsafe-base64": "^1.0.0"
-      }
-    },
-    "@webex/common-evented": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/common-evented/-/common-evented-1.59.0.tgz",
-      "integrity": "sha512-u7A00gJoqgz1y8s1ACWO5q1JrquAF89I8FO6e9C1w/SlXZnIYYSD4X216dzNYnX/uBDNXS2ePkklnWyH0YvBYw==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/common-timers": {
-      "version": "1.58.5",
-      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.58.5.tgz",
-      "integrity": "sha512-DwP0G4Ab4jdnub2Paxm01JKCn0BDM9hzKvvVc6eWm50/alzZH0Np8wv6MgMu5/wc3UqYLsHTJ6W6JzMW9xcNZw==",
-      "requires": {
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/helper-html": {
-      "version": "1.58.5",
-      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.58.5.tgz",
-      "integrity": "sha512-3wMtZaMFc+IJ1vEdjwlflNezuEUWL7gQR6OPg7nS5+Q38Rp5UPlCpPoCXZXfZu3ECcfpl8HakBuhbUwicF1Dbw==",
-      "requires": {
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      }
-    },
-    "@webex/helper-image": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.59.0.tgz",
-      "integrity": "sha512-AvQckU+DwIAOgyU7VyHQ0SQ17kHeRiwEopE6C0X02pG9LJG+7Z/MGDV9wnGnqL/Utf59UnMCDECYMwdczrikqw==",
-      "requires": {
-        "@webex/http-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "exif": "^0.6.0",
-        "gm": "^1.23.0",
-        "lodash": "^4.17.11",
-        "mime-types": "^2.1.15"
-      }
-    },
-    "@webex/http-core": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.59.0.tgz",
-      "integrity": "sha512-JDtUEKkPPAWsSJNLULTOydkZsRLPFEuFmL3PWpm7Gezp/XiiBSQLHjZo1wBe2kK2LTYGb9//bEXcmpZy095u5g==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "file-type": "^3.9.0",
-        "global": "^4.3.1",
-        "is-function": "^1.0.1",
-        "lodash": "^4.17.11",
-        "parse-headers": "^2.0.1",
-        "qs": "^6.5.1",
-        "request": "^2.81.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "@webex/internal-plugin-conversation": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.59.0.tgz",
-      "integrity": "sha512-uQQNpVV2E7h+G2GNxQbyFvA9wMT4aCKN2AMF8cJN4oy90DInDcvKWnsR7XrFHoGuZu4g5pGM9RFZrHyp3FhkSA==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/helper-html": "1.58.5",
-        "@webex/helper-image": "1.59.0",
-        "@webex/internal-plugin-encryption": "1.59.0",
-        "@webex/internal-plugin-user": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1"
-      }
-    },
-    "@webex/internal-plugin-encryption": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.59.0.tgz",
-      "integrity": "sha512-rafd2UgAOvz1oCaOthO/jmcjCknlcgKgdJbqBxu5juqkZpnnGiWQB4UJN8hPQtD2HgRRzgozGQiP+akAKmbAvw==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/common-timers": "1.58.5",
-        "@webex/http-core": "1.59.0",
-        "@webex/internal-plugin-mercury": "1.59.0",
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "node-jose": "^0.11.0",
-        "node-kms": "^0.3.2",
-        "node-scr": "^0.2.2"
-      }
-    },
-    "@webex/internal-plugin-feature": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.59.0.tgz",
-      "integrity": "sha512-P7UH9bEM484KtlgQgrfbPTY6JcaRAtgmc9HGRn+Mx+aautlgtSMrjIeDLfvgRdLZCFuDDHboz3q3lP7T8eaF8g==",
-      "requires": {
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      }
-    },
-    "@webex/internal-plugin-locus": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-locus/-/internal-plugin-locus-1.59.0.tgz",
-      "integrity": "sha512-b4NBq1UCsfMU86AxPN0XsXSsls87ijj3U7u+ADB0snn9T5OnZ+yF50CvP6aNDplhAdmtJf6bZ5wtb13moo14rQ==",
-      "requires": {
-        "@webex/internal-plugin-mercury": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1"
-      }
-    },
-    "@webex/internal-plugin-mercury": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.59.0.tgz",
-      "integrity": "sha512-hMf4MlE70F7dkIZZHbkQ+ie6GZ9BpeB6rvBUJPLu66ofNNKm6AVhbtgqHiEN9IEkMndzanF1VCs3vSFdhbXyDQ==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/common-timers": "1.58.5",
-        "@webex/internal-plugin-feature": "1.59.0",
-        "@webex/internal-plugin-metrics": "1.59.0",
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "backoff": "^2.5.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1",
-        "ws": "^4.0.0"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "@webex/internal-plugin-metrics": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.59.0.tgz",
-      "integrity": "sha512-fLwTJAIjkNSupNBXvZ8gOofbS20+htgfvoSI9DvqNm+aZxvEBFsxqfAi2fVg+EDdAK38F/mvfNOW9tVpXum4kg==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/common-timers": "1.58.5",
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/internal-plugin-user": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.59.0.tgz",
-      "integrity": "sha512-z3c0TogmGQmmBQUUFPGMN8ODmayuey3pwOUtFMbvzSOSb35U5/xTOptucW63BYROgdOx668uPeO+adDQ0opmyg==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      }
-    },
-    "@webex/internal-plugin-wdm": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-wdm/-/internal-plugin-wdm-1.59.0.tgz",
-      "integrity": "sha512-Vw1A5g/Z3bSip2otTwNmLhNYzsYUVtiSp53NhYA5NaaJis0TvGYbuQtoEoQ0Sxwks4bGoJXZbxBK87N48noIlg==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/common-timers": "1.58.5",
-        "@webex/http-core": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "ampersand-collection": "^2.0.2",
-        "ampersand-state": "^5.0.2",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      }
-    },
-    "@webex/media-engine-webrtc": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/media-engine-webrtc/-/media-engine-webrtc-1.59.0.tgz",
-      "integrity": "sha512-9TNdDq3ADTZZzVIOgp1p634dOwKRdLfUPCdJ3QO4hHoDsbC+AX8OX25s2PilyMP57FFQPFK5/A7ibvTvyo3Fgw==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/common-evented": "1.59.0",
-        "ampersand-events": "^2.0.2",
-        "babel-runtime": "^6.23.0",
-        "bowser": "1.9.4",
-        "core-decorators": "^0.20.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "lodash-decorators": "^4.3.4",
-        "sdp-transform": "^2.4.0",
-        "webrtc-adapter": "^6.1.0"
-      }
-    },
-    "@webex/plugin-authorization": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.59.0.tgz",
-      "integrity": "sha512-S8PHaiPQrp3eakEazrxPzjrhxjrupByqu51d7zRF/hYOnMrV7zeW2z//yLwY+0ctO99JUcIqVvCpGWcK39p54w==",
-      "requires": {
-        "@webex/plugin-authorization-browser": "1.59.0",
-        "@webex/plugin-authorization-node": "1.59.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/plugin-authorization-browser": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.59.0.tgz",
-      "integrity": "sha512-Vou55PXJok+WAa5TemoR4nuzWXJ9Bnphx9KakYJPxF5Oo4Vi4O43+IqCgcI4Oh7hQZr7kxn7OfG0jala3iNyfw==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1"
-      }
-    },
-    "@webex/plugin-authorization-node": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.59.0.tgz",
-      "integrity": "sha512-NLm2g64B4FP1aKZc57V53bzEydG02cxo4UZvd3YwaRY6vQ4vHx5wOEkldfJIXtMXxAwf55ew6iZp8iwthxbhCQ==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/plugin-logger": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.59.0.tgz",
-      "integrity": "sha512-AfJBs0nqzlIwiaalfyCiz23NeXx7N8D9HuflftyHGvCZNxq4vLmx7wmfP/QIe2YyaxKHr27a1xnl6cXnEIiECw==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      }
-    },
-    "@webex/plugin-memberships": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.59.0.tgz",
-      "integrity": "sha512-c28+5/hhW5ISdoEuzZ3vwYnVdaLXmenNEDV+8KwbZV65SX60k7at1TGRw5Kj1wkcFmzHEyJAYnPq7fkDmSSwdA==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/internal-plugin-conversation": "1.59.0",
-        "@webex/internal-plugin-mercury": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "debug": "^3.1.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "@webex/plugin-messages": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.59.0.tgz",
-      "integrity": "sha512-FxUz0JZtPNPH4UddZ69BM7Rd8k0QEyrvLQ6PfCDpWbhYtMbtIVbf+NB6jFQZrI780CjwW7G3mKb/KTQpx9oxQQ==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/internal-plugin-conversation": "1.59.0",
-        "@webex/internal-plugin-mercury": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "debug": "^3.1.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "@webex/plugin-people": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.59.0.tgz",
-      "integrity": "sha512-wu61+XpH32DhnmngfbexN1YCfqXOPhv1wuQsDjXjNTQaQpzNRB6kLhBxnQdUGtruDnOEPO5DS+kCYOlyLqqTCg==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/plugin-phone": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-phone/-/plugin-phone-1.59.0.tgz",
-      "integrity": "sha512-ofCyr0NxwiBXAkZHhHmLAa4Y1bIS+fmk7Vempay33itmk3L75WQdc9gCMM6mV6e60Z6whHy9Enkejc18Vvb1/Q==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/common-timers": "1.58.5",
-        "@webex/internal-plugin-locus": "1.59.0",
-        "@webex/internal-plugin-metrics": "1.59.0",
-        "@webex/media-engine-webrtc": "1.59.0",
-        "@webex/plugin-people": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "ampersand-collection": "^2.0.2",
-        "ampersand-collection-lodash-mixin": "^4.0.0",
-        "ampersand-state": "^5.0.2",
-        "babel-runtime": "^6.23.0",
-        "detectrtc": "^1.3.4",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "lodash-decorators": "^4.3.4",
-        "sdp-transform": "^2.4.0",
-        "uuid": "^3.2.1"
-      }
-    },
-    "@webex/plugin-rooms": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.59.0.tgz",
-      "integrity": "sha512-raYJ/qNXlveqTfaq2Zv6hqnTHgw1M6/fMAnWZgmOIOSr3bNBnmxpZb3wyFetGh2/NZD2SuXHC/b0Ox0euUZ8vw==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/internal-plugin-conversation": "1.59.0",
-        "@webex/internal-plugin-mercury": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "debug": "^3.1.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "@webex/plugin-team-memberships": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.59.0.tgz",
-      "integrity": "sha512-UMaHAQz+qMeZrr3JGzpCy96qq2BzjolVrYxj4RnbWL7pJc12xaZZLvLjjNPirpmGsqpZKeMavusw6dp+S7Em6Q==",
-      "requires": {
-        "@webex/webex-core": "1.59.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/plugin-teams": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.59.0.tgz",
-      "integrity": "sha512-tc8wjAi+ZvukX1xHFGIJ+STFu/UtLo1n4CWi7SDk7uWC4lP9CMcjswYlT5Lohyt66I9F1q4KiWdhksbmqrRLeA==",
-      "requires": {
-        "@webex/webex-core": "1.59.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/plugin-webhooks": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.59.0.tgz",
-      "integrity": "sha512-h+tX+X00LOdsbnmVdyhxMnM7pyO27kYBoKR1IqKBdBRr+TX+zUmfSaUFtjUlDVaArYh/vQTdDGCSr5vb/O2v3A==",
-      "requires": {
-        "@webex/webex-core": "1.59.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/storage-adapter-local-storage": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.59.0.tgz",
-      "integrity": "sha512-gkAk0/IFc9n3UC0bht0R5kGQlXtTqS1w4Y93x7B61fvOuFJZLYLdaqtZb/ZNS86pTkKWg2UkS/vlx/MXyJjwJQ==",
-      "requires": {
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/webex-core": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.59.0.tgz",
-      "integrity": "sha512-VHVHQ3X2UWT2Jf/ZoNGcxCg6UmuOY2OCi/+lD9fesIVLTHFptJiCt0k5NOFd9w042eSfsTfu3FjFLavwiPKvlQ==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/common-timers": "1.58.5",
-        "@webex/http-core": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "ampersand-collection": "^2.0.2",
-        "ampersand-events": "^2.0.2",
-        "ampersand-state": "^5.0.2",
-        "babel-runtime": "^6.23.0",
-        "core-decorators": "^0.20.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1"
-      }
-    },
-    "@xmpp/jid": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@xmpp/jid/-/jid-0.0.2.tgz",
-      "integrity": "sha1-DVKMqdWNr8gzZlVk/+YvMyoxZ/I="
-    },
-    "@xmpp/streamparser": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@xmpp/streamparser/-/streamparser-0.0.6.tgz",
-      "integrity": "sha1-EYAz6p23yGoctGED8mnr/3n28eo=",
-      "requires": {
-        "@xmpp/xml": "^0.1.3",
-        "inherits": "^2.0.3",
-        "ltx": "^2.5.0"
-      }
-    },
-    "@xmpp/xml": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@xmpp/xml/-/xml-0.1.3.tgz",
-      "integrity": "sha1-HxQ5nlPkGWiFWGmPbGLnHjmoam4=",
-      "requires": {
-        "inherits": "^2.0.3",
-        "ltx": "^2.6.2"
-      }
-    },
     "abab": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.2.tgz",
@@ -1416,16 +973,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
-    },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
       "version": "1.3.7",
@@ -1479,13 +1027,10 @@
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
       "dev": true
     },
-    "agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-      "requires": {
-        "es6-promisify": "^5.0.0"
-      }
+    "adm-zip": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
+      "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA=="
     },
     "ajv": {
       "version": "6.9.1",
@@ -1496,64 +1041,6 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
-      }
-    },
-    "ampersand-class-extend": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ampersand-class-extend/-/ampersand-class-extend-2.0.0.tgz",
-      "integrity": "sha1-Uolf+lkhdjSmGI/RhLEEj12Aiv8=",
-      "requires": {
-        "lodash": "^4.11.1"
-      }
-    },
-    "ampersand-collection": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ampersand-collection/-/ampersand-collection-2.0.2.tgz",
-      "integrity": "sha512-IjDa4HTL/tdQDDL0SGyWk4AHD02iNtUSLRWkAsJ2biPvapljW9HNgIEIdbPnnR+7Gb9BJkjesaLNjVZfAMzeuA==",
-      "requires": {
-        "ampersand-class-extend": "^2.0.0",
-        "ampersand-events": "^2.0.1",
-        "ampersand-version": "^1.0.2",
-        "lodash": "^4.11.1"
-      }
-    },
-    "ampersand-collection-lodash-mixin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ampersand-collection-lodash-mixin/-/ampersand-collection-lodash-mixin-4.0.0.tgz",
-      "integrity": "sha1-DtBHqOc8sHC8NrZ4pGPjgqyNtt0=",
-      "requires": {
-        "ampersand-version": "^1.0.0",
-        "lodash": "^4.6.1"
-      }
-    },
-    "ampersand-events": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-2.0.2.tgz",
-      "integrity": "sha1-9AK8LhgwX6vZldvc07cFe73X00c=",
-      "requires": {
-        "ampersand-version": "^1.0.2",
-        "lodash": "^4.6.1"
-      }
-    },
-    "ampersand-state": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/ampersand-state/-/ampersand-state-5.0.3.tgz",
-      "integrity": "sha512-sr904K5zvw6mkGjFHhTcfBIdpoJ6mn/HrFg7OleRmBpw3apLb3Z0gVrgRTb7kK1wOLI34vs4S+IXqNHUeqWCzw==",
-      "requires": {
-        "ampersand-events": "^2.0.1",
-        "ampersand-version": "^1.0.0",
-        "array-next": "~0.0.1",
-        "key-tree-store": "^1.3.0",
-        "lodash": "^4.12.0"
-      }
-    },
-    "ampersand-version": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ampersand-version/-/ampersand-version-1.0.2.tgz",
-      "integrity": "sha1-/489TOrE0yzNg/a9Zpc5f3tZ4sA=",
-      "requires": {
-        "find-root": "^0.1.1",
-        "through2": "^0.6.3"
       }
     },
     "ansi-align": {
@@ -1604,15 +1091,11 @@
       "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
       "dev": true
     },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1659,11 +1142,6 @@
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
-    "array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
-    },
     "array-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
@@ -1690,21 +1168,6 @@
         "es-abstract": "^1.7.0"
       }
     },
-    "array-next": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/array-next/-/array-next-0.0.1.tgz",
-      "integrity": "sha1-5eRmCkwn/agVH/d2QnXQCQAGK+E="
-    },
-    "array-parallel": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
-      "integrity": "sha1-j3hTCJJu1apHjEfmTRszS2wMlH0="
-    },
-    "array-series": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz",
-      "integrity": "sha1-3103v8XC7wdV4qpPkv6ufUtaly8="
-    },
     "array-slice": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
@@ -1715,17 +1178,21 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
         "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "util": "0.10.3"
       }
     },
     "assert-plus": {
@@ -1744,14 +1211,6 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
-    "async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
-      "requires": {
-        "lodash": "^4.17.11"
-      }
-    },
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -1761,7 +1220,8 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1798,11 +1258,6 @@
           "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
         }
       }
-    },
-    "b64u": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/b64u/-/b64u-2.0.0.tgz",
-      "integrity": "sha512-N3SnhKhQtwm9a4+rdNT0JvnNdPlRwpQZN4tfJwOE3/qJVzM+OlYj/Iz2n1S3KXAQmKHaRwWUNW5gEnjuD8cXHg=="
     },
     "babel-eslint": {
       "version": "10.0.2",
@@ -1905,23 +1360,6 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-        }
-      }
-    },
     "babel-preset-jest": {
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.0.0.tgz",
@@ -1932,36 +1370,10 @@
         "babel-plugin-jest-hoist": "^25.0.0"
       }
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "back": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/back/-/back-1.0.2.tgz",
-      "integrity": "sha1-qT9ebOaXKZhNWQGiuxbjsBpNY2k=",
-      "requires": {
-        "xtend": "^4.0.0"
-      }
-    },
-    "backoff": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
-      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
-      "requires": {
-        "precond": "0.2"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -2026,6 +1438,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bignumber.js": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+    },
     "binary-extensions": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -2071,67 +1488,104 @@
       }
     },
     "botbuilder": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-3.16.0.tgz",
-      "integrity": "sha512-Gf51aNfvBuAxKSXQ+1SV/P1lzuRMyMyIqvjUUSqpjbtW6lFkPHhCmJIM0Dgxbflq78EXXisIYZQgAqsUNYeVQQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.6.0.tgz",
+      "integrity": "sha512-dXfyAjobTyJ5ViOurEt088uOw82cpuzQB+L1J041GbEBZ/DzjAAC/8TMGn++j4++kzE6WsFc+D0hZuBAF2YzgA==",
       "requires": {
-        "@types/async": "^2.0.48",
-        "@types/express": "^4.11.1",
-        "@types/form-data": "^2.2.1",
-        "@types/jsonwebtoken": "^7.2.6",
-        "@types/node": "^9.6.1",
-        "@types/request": "^2.47.0",
-        "@types/sprintf-js": "^1.1.0",
-        "@types/url-join": "^0.8.1",
-        "async": "^1.5.2",
-        "base64url": "^3.0.0",
-        "chrono-node": "^1.1.3",
-        "jsonwebtoken": "^8.2.2",
-        "promise": "^7.1.1",
-        "request": "^2.88.0",
-        "rsa-pem-from-mod-exp": "^0.8.4",
-        "sprintf-js": "^1.0.3",
-        "url-join": "^1.1.0"
+        "@types/node": "^10.12.18",
+        "botbuilder-core": "^4.6.0",
+        "botframework-connector": "^4.6.0",
+        "filenamify": "^4.1.0",
+        "fs-extra": "^7.0.1"
+      }
+    },
+    "botbuilder-adapter-slack": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/botbuilder-adapter-slack/-/botbuilder-adapter-slack-1.0.6.tgz",
+      "integrity": "sha512-EKgecx3kanAeaw2Rc1YMGHPPzv/pMRKpEZDsV73n7BCa1UeQrdsg/cHKBemEdOApE5af2CVyUqw1j1E2JwlREA==",
+      "requires": {
+        "@slack/web-api": "^5.2.1",
+        "botbuilder": "^4.6.0",
+        "botkit": "^4.6.0",
+        "debug": "^4.1.0"
       },
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
-    "botkit": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/botkit/-/botkit-0.7.4.tgz",
-      "integrity": "sha512-HMVWQ4fY6Xyb62SrFrEbBgKDaJiT7gbs2lva4SPdoq47jFkzgJ1wDKqkTsW+p+WMSVsHx9OaLKwyzxkrr0t6Gg==",
+    "botbuilder-core": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.6.0.tgz",
+      "integrity": "sha512-NrZENrtKDoe6SlFhc+tSdkSbC9qWhEFrk60VOUiT6Q4OMfz0eFZc3HwrcN2obcYc5eQteW+zCEvvi/r41DLP4g==",
       "requires": {
-        "async": "^2.6.1",
-        "back": "^1.0.2",
+        "assert": "^1.4.1",
+        "botframework-schema": "^4.6.0"
+      }
+    },
+    "botbuilder-dialogs": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/botbuilder-dialogs/-/botbuilder-dialogs-4.6.0.tgz",
+      "integrity": "sha512-mDpxbh6A9DcXHXHQNkVHqWmyARtdrI3CyIEwa244n2O/KH9LKMQ+71oSwl82Qm8lsQTTAZ93atFQcgtMDtuEmQ==",
+      "requires": {
+        "@microsoft/recognizers-text-choice": "1.1.4",
+        "@microsoft/recognizers-text-date-time": "1.1.4",
+        "@microsoft/recognizers-text-number": "1.1.4",
+        "@microsoft/recognizers-text-suite": "1.1.4",
+        "@types/node": "^10.12.18",
+        "botbuilder-core": "^4.6.0",
+        "cldr-data": "^35.1.0",
+        "globalize": "^1.4.2"
+      }
+    },
+    "botframework-connector": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.6.0.tgz",
+      "integrity": "sha512-sbqSWpZBC+0hA7+ExyaSJOy88XeuINTGWSOcAxx5JyJAXosBr0Bdd4y+I4evq5VhSj3GME2g/DYa8d73i/mFMQ==",
+      "requires": {
+        "@azure/ms-rest-js": "1.2.6",
+        "@types/jsonwebtoken": "7.2.8",
+        "@types/node": "^10.12.18",
+        "base64url": "^3.0.0",
+        "botframework-schema": "^4.6.0",
+        "form-data": "^2.3.3",
+        "jsonwebtoken": "8.0.1",
+        "node-fetch": "^2.2.1",
+        "rsa-pem-from-mod-exp": "^0.8.4"
+      }
+    },
+    "botframework-schema": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.6.0.tgz",
+      "integrity": "sha512-3ndSI2S17Do6RRncYN3Z+N1bkui9HPHIw2lyIGjyX7grukmAcnex/xfpafK++UqmhvF65OdY/Xa4njn7E/tKEQ=="
+    },
+    "botkit": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/botkit/-/botkit-4.6.1.tgz",
+      "integrity": "sha512-7tp1ADFPJX6hcHxhxBH3bfZUGBlp7BYgOcfBedGcJsoibzUDZe5yXFxjiDPAw1UhpgeeWvRx0cWZTQuVuTDzHA==",
+      "requires": {
         "body-parser": "^1.18.3",
-        "botbuilder": "^3.16.0",
-        "botkit-studio-sdk": "^1.0.8",
-        "chalk": "^2.4.1",
-        "ciscospark": "^1.48.0",
-        "clone": "2.1.2",
-        "command-line-args": "^5.0.2",
-        "command-line-usage": "^5.0.5",
+        "botbuilder": "^4.6.0",
+        "botbuilder-dialogs": "^4.6.0",
+        "botframework-connector": "^4.6.0",
         "debug": "^4.1.0",
-        "email-addresses": "^3.0.2",
         "express": "^4.16.4",
-        "googleapis": "^34.0.0",
-        "https-proxy-agent": "^2.2.1",
-        "jfs": "^0.3.0",
-        "localtunnel": "^1.9.1",
-        "md5": "^2.2.1",
-        "mustache": "^3.0.0",
-        "prompts": "^1.1.1",
+        "hbs": "^4.0.1",
+        "mustache": "^3.0.1",
+        "path": "^0.12.7",
         "request": "^2.88.0",
-        "requestretry": "^3.0.2",
-        "simple-xmpp": "^1.3.0",
-        "twilio": "^3.23.1",
-        "ware": "^1.3.0",
-        "ws": "^6.1.0"
+        "ware": "^1.3.0"
       },
       "dependencies": {
         "debug": {
@@ -2221,30 +1675,6 @@
         }
       }
     },
-    "botkit-studio-sdk": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/botkit-studio-sdk/-/botkit-studio-sdk-1.0.9.tgz",
-      "integrity": "sha512-B+WBPeAFJ8aAuXYbkS7sOx6YtV0m2IXwn0xMxKhjRtIES9q10PjABZX5aLao8wtwWJ2PXggMhJJqbmLejn8PWA==",
-      "requires": {
-        "promise": "^8.0.2",
-        "request": "^2.88.0"
-      },
-      "dependencies": {
-        "promise": {
-          "version": "8.0.3",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
-          "integrity": "sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==",
-          "requires": {
-            "asap": "~2.0.6"
-          }
-        }
-      }
-    },
-    "bowser": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
-      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
-    },
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
@@ -2303,7 +1733,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2341,11 +1770,6 @@
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
       "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
       "dev": true
-    },
-    "browser-request": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
-      "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
     },
     "browser-resolve": {
       "version": "1.11.3",
@@ -2416,11 +1840,6 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
-    "camelcase": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-    },
     "capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -2445,6 +1864,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2456,11 +1876,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
-    },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "chokidar": {
       "version": "2.1.6",
@@ -2511,42 +1926,11 @@
         }
       }
     },
-    "chrono-node": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.3.11.tgz",
-      "integrity": "sha512-jDWRnY6nYvzfV3HPYBqo+tot7tcsUs9i3arGbMdI0TouPSXP2C2y/Ctp27rxKTQDi6yuTxAB2cw+Q6igGhOhdQ==",
-      "requires": {
-        "moment": "2.21.0"
-      }
-    },
     "ci-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
       "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "dev": true
-    },
-    "ciscospark": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/ciscospark/-/ciscospark-1.59.0.tgz",
-      "integrity": "sha512-uozxQp0KUFCtl/P2jE/aiSizahOAue9qxQH0fguR0wT+WZXkOaP4Aqan7sgIbQVRgP4h/S49LVLA787mfVGSpg==",
-      "requires": {
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/plugin-authorization": "1.59.0",
-        "@webex/plugin-logger": "1.59.0",
-        "@webex/plugin-memberships": "1.59.0",
-        "@webex/plugin-messages": "1.59.0",
-        "@webex/plugin-people": "1.59.0",
-        "@webex/plugin-phone": "1.59.0",
-        "@webex/plugin-rooms": "1.59.0",
-        "@webex/plugin-team-memberships": "1.59.0",
-        "@webex/plugin-teams": "1.59.0",
-        "@webex/plugin-webhooks": "1.59.0",
-        "@webex/storage-adapter-local-storage": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-polyfill": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      }
     },
     "class-utils": {
       "version": "0.3.6",
@@ -2569,6 +1953,146 @@
         }
       }
     },
+    "cldr-data": {
+      "version": "35.1.0",
+      "resolved": "https://registry.npmjs.org/cldr-data/-/cldr-data-35.1.0.tgz",
+      "integrity": "sha512-HreWlQ/Yy4AZVGD9aB6cOvpwPYGW3Vss62Bhojcy7r/MgX13PZsr90ujwcAlLATA0o2446H04MD6OqZRfJ84aw==",
+      "requires": {
+        "cldr-data-downloader": "0.3.x",
+        "glob": "5.x.x"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "cldr-data-downloader": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/cldr-data-downloader/-/cldr-data-downloader-0.3.5.tgz",
+      "integrity": "sha512-uyIMa1K98DAp/PE7dYpq2COIrkWn681Atjng1GgEzeJzYb1jANtugtp9wre6+voE+qzVC8jtWv6E/xZ1GTJdlw==",
+      "requires": {
+        "adm-zip": "0.4.11",
+        "mkdirp": "0.5.0",
+        "nopt": "3.0.x",
+        "progress": "1.1.8",
+        "q": "1.0.1",
+        "request": "~2.87.0",
+        "request-progress": "0.3.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+        },
+        "progress": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "request": {
+          "version": "2.87.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "requires": {
+            "punycode": "^1.4.1"
+          }
+        }
+      }
+    },
+    "cldrjs": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/cldrjs/-/cldrjs-0.5.1.tgz",
+      "integrity": "sha512-xyiP8uAm8K1IhmpDndZLraloW1yqu0L+HYdQ7O1aGPxx9Cr+BMnPANlNhSt++UKfxytL2hd2NPXgTjiy7k43Ew=="
+    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -2590,30 +2114,10 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
-    "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-    },
     "co": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
-      "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -2628,6 +2132,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -2635,7 +2140,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "colorette": {
       "version": "1.1.0",
@@ -2650,48 +2156,10 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "command-line-args": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
-      "requires": {
-        "array-back": "^3.0.1",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      }
-    },
-    "command-line-usage": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.5.tgz",
-      "integrity": "sha512-d8NrGylA5oCXSbGoKz05FkehDAzSmIm4K03S5VDh4d5lZAtTWfc3D1RuETtuQCn8129nYfJfDdF7P/lwcz1BlA==",
-      "requires": {
-        "array-back": "^2.0.0",
-        "chalk": "^2.4.1",
-        "table-layout": "^0.4.3",
-        "typical": "^2.6.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "requires": {
-            "typical": "^2.6.1"
-          }
-        },
-        "typical": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
-        }
-      }
-    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
       "optional": true
     },
     "component-emitter": {
@@ -2702,8 +2170,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "configstore": {
       "version": "3.1.2",
@@ -2762,16 +2229,6 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
-    "core-decorators": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/core-decorators/-/core-decorators-0.20.0.tgz",
-      "integrity": "sha1-YFiWYkBTr4wo775zXCWjAaYcZcU="
-    },
-    "core-js": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2785,20 +2242,6 @@
       "requires": {
         "capture-stack-trace": "^1.0.0"
       }
-    },
-    "cross-spawn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-      "requires": {
-        "lru-cache": "^4.0.1",
-        "which": "^1.2.9"
-      }
-    },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -2859,7 +2302,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -2869,7 +2313,8 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -2932,11 +2377,6 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
-    "deprecate": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/deprecate/-/deprecate-1.0.0.tgz",
-      "integrity": "sha1-ZhSQ7SQokWpsiIPYg05WRvTkpKg="
-    },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -2953,11 +2393,6 @@
       "integrity": "sha512-JAP22dVPAqvhdRFFxK1G5GViIokyUn0UWXRNW0ztK96fsqi9cuM8w8ESbSk+T2w5OVorcMcL6m7yUg1RrX+2CA==",
       "dev": true
     },
-    "detectrtc": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/detectrtc/-/detectrtc-1.3.9.tgz",
-      "integrity": "sha512-uDmANQib8St/dRppyQGXHX36qG2wel5dKHslqz0qr2958rcpN6heOzofV2PoKi7ogtCXpQuz0JUzazWhnLBPcA=="
-    },
     "diff-sequences": {
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.0.0.tgz",
@@ -2972,11 +2407,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "domexception": {
       "version": "1.0.1",
@@ -3029,11 +2459,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
-    "email-addresses": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.1.0.tgz",
-      "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg=="
-    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -3054,19 +2479,11 @@
         "once": "^1.4.0"
       }
     },
-    "envify": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/envify/-/envify-4.1.0.tgz",
-      "integrity": "sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==",
-      "requires": {
-        "esprima": "^4.0.0",
-        "through": "~2.3.4"
-      }
-    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -3092,19 +2509,6 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
-      }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
       }
     },
     "escape-html": {
@@ -3495,7 +2899,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.0.1",
@@ -3532,10 +2937,10 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    "eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "exec-sh": {
       "version": "0.3.2",
@@ -3585,14 +2990,6 @@
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
-      }
-    },
-    "exif": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/exif/-/exif-0.6.0.tgz",
-      "integrity": "sha1-YKYmaAdlQst+T1cZnUrG830sX0o=",
-      "requires": {
-        "debug": "^2.2"
       }
     },
     "exit": {
@@ -3867,16 +3264,26 @@
         "flat-cache": "^2.0.1"
       }
     },
-    "file-type": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
-    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "dev": true
+    },
+    "filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
+    },
+    "filenamify": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.1.0.tgz",
+      "integrity": "sha512-KQV/uJDI9VQgN7sHH1Zbk6+42cD6mnQ2HONzkXUfPJ+K2FC8GZ1dpewbbHw0Sz8Tf5k3EVdHVayM4DoAwWlmtg==",
+      "requires": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      }
     },
     "fill-range": {
       "version": "4.0.0",
@@ -3911,28 +3318,6 @@
         "parseurl": "~1.3.3",
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
-      }
-    },
-    "find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "requires": {
-        "array-back": "^3.0.1"
-      }
-    },
-    "find-root": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz",
-      "integrity": "sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE="
-    },
-    "find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
       }
     },
     "findup-sync": {
@@ -3998,14 +3383,6 @@
         }
       }
     },
-    "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "requires": {
-        "is-callable": "^1.1.3"
-      }
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -4018,6 +3395,11 @@
       "requires": {
         "for-in": "^1.0.1"
       }
+    },
+    "foreachasync": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
+      "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -4051,6 +3433,16 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -4617,32 +4009,6 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "gaxios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.8.4.tgz",
-      "integrity": "sha512-BoENMnu1Gav18HcpV9IleMPZ9exM+AvUjrAOV4Mzs/vfz2Lu/ABv451iEXByKiMPn2M140uul1txXCg83sAENw==",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^2.2.1",
-        "node-fetch": "^2.3.0"
-      }
-    },
-    "gcp-metadata": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.7.0.tgz",
-      "integrity": "sha512-ffjC09amcDWjh3VZdkDngIo7WoluyC5Ag9PAYxZbmQLOLNI8lvPtoKTSCyU54j2gwy5roZh6sSMTfkY2ct7K3g==",
-      "requires": {
-        "axios": "^0.18.0",
-        "extend": "^3.0.1",
-        "retry-axios": "0.3.2"
-      }
-    },
-    "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
-    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -4696,15 +4062,6 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
-    },
     "global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -4736,111 +4093,19 @@
         "which": "^1.2.14"
       }
     },
+    "globalize": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/globalize/-/globalize-1.4.2.tgz",
+      "integrity": "sha512-IfKeYI5mAITBmT5EnH8kSQB5uGson4Fkj2XtTpyEbIS7IHNfLHoeTyLJ6tfjiKC6cJXng3IhVurDk5C7ORqFhQ==",
+      "requires": {
+        "cldrjs": "^0.5.0"
+      }
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
-    },
-    "gm": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/gm/-/gm-1.23.1.tgz",
-      "integrity": "sha1-Lt7rlYCE0PjqeYjl2ZWxx9/BR3c=",
-      "requires": {
-        "array-parallel": "~0.1.3",
-        "array-series": "~0.1.5",
-        "cross-spawn": "^4.0.0",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "google-auth-library": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-2.0.2.tgz",
-      "integrity": "sha512-FURxmo1hBVmcfLauuMRKOPYAPKht3dGuI2wjeJFalDUThO0HoYVjr4yxt5cgYSFm1dgUpmN9G/poa7ceTFAIiA==",
-      "requires": {
-        "axios": "^0.18.0",
-        "gcp-metadata": "^0.7.0",
-        "gtoken": "^2.3.0",
-        "https-proxy-agent": "^2.2.1",
-        "jws": "^3.1.5",
-        "lru-cache": "^5.0.0",
-        "semver": "^5.5.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-        }
-      }
-    },
-    "google-p12-pem": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.4.tgz",
-      "integrity": "sha512-SwLAUJqUfTB2iS+wFfSS/G9p7bt4eWcc2LyfvmUXe7cWp6p3mpxDo6LLI29MXdU6wvPcQ/up298X7GMC5ylAlA==",
-      "requires": {
-        "node-forge": "^0.8.0",
-        "pify": "^4.0.0"
-      },
-      "dependencies": {
-        "node-forge": {
-          "version": "0.8.5",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
-          "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
-        }
-      }
-    },
-    "googleapis": {
-      "version": "34.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-34.0.0.tgz",
-      "integrity": "sha512-nGfTSrlQF77HDNOHDy0ii3ET1h8Yap6QXxkfMZsre+7hBg91g4RsgrA50BgrOXpbNlQCBOGXWhUsa267kVeA/Q==",
-      "requires": {
-        "google-auth-library": "^2.0.0",
-        "googleapis-common": "^0.3.0"
-      }
-    },
-    "googleapis-common": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-0.3.0.tgz",
-      "integrity": "sha512-OqQ2iskzjPHLoM+AXk7e/TmEsdgxyAk8PVbMg0S8v2wPhgMu2wTawEL7zH9QG236u/RqQ1Ak120oSWsamPnWGg==",
-      "requires": {
-        "axios": "^0.18.0",
-        "google-auth-library": "^2.0.0",
-        "pify": "^3.0.0",
-        "qs": "^6.5.2",
-        "url-template": "^2.0.8",
-        "uuid": "^3.2.1"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
-      }
     },
     "got": {
       "version": "6.7.1",
@@ -4866,30 +4131,16 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
-    },
-    "gtoken": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.3.tgz",
-      "integrity": "sha512-EaB49bu/TCoNeQjhCYKI/CurooBKkGxIqFHsWABW0b25fobBYVTMe84A8EBVVZhl8emiUdNypil9huMOTmyAnw==",
-      "requires": {
-        "gaxios": "^1.0.4",
-        "google-p12-pem": "^1.0.0",
-        "jws": "^3.1.5",
-        "mime": "^2.2.0",
-        "pify": "^4.0.0"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
-        }
-      }
     },
     "handlebars": {
       "version": "4.5.1",
@@ -4936,7 +4187,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -4972,13 +4224,31 @@
         }
       }
     },
-    "hash-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+    "hbs": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/hbs/-/hbs-4.0.6.tgz",
+      "integrity": "sha512-KFt3Y4zOvVQOp84TmqVaFTpBTYO1sVenBoBY712MI3vPkKxVoO6AsuEyDayIRPRAHRYZHHWnmc4spFa8fhQpLw==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "handlebars": "4.3.5",
+        "walk": "2.3.14"
+      },
+      "dependencies": {
+        "handlebars": {
+          "version": "4.3.5",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.5.tgz",
+          "integrity": "sha512-I16T/l8X9DV3sEkY9sK9lsPRgDsj82ayBY/4pAZyP2BcX5WeRM3O06bw9kIs2GLrHvFB/DNzWWJyFvof8wQGqw==",
+          "requires": {
+            "neo-async": "^2.6.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "homedir-polyfill": {
@@ -4992,7 +4262,8 @@
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -5023,30 +4294,6 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-      "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
       }
     },
     "iconv-lite": {
@@ -5165,7 +4412,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5274,11 +4520,6 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-    },
     "ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
@@ -5320,7 +4561,8 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -5399,19 +4641,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
-    },
-    "is-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -5521,8 +4750,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -5545,11 +4773,6 @@
         "unc-path-regex": "^0.1.2"
       }
     },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -5560,11 +4783,6 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
@@ -7322,27 +6540,6 @@
         }
       }
     },
-    "jfs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/jfs/-/jfs-0.3.0.tgz",
-      "integrity": "sha1-WrzkRkOw0NLZUWQ5aGjyK7FViwQ=",
-      "requires": {
-        "async": "~2.5.0",
-        "clone": "~2.1.1",
-        "mkdirp": "~0.5.1",
-        "uuid": "^3.1.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "requires": {
-            "lodash": "^4.14.0"
-          }
-        }
-      }
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7466,12 +6663,20 @@
         }
       }
     },
-    "jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "jws": "^3.2.2",
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsonwebtoken": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
+      "integrity": "sha1-UNrvjQqMfeLNBrwQE7dbBMzz8M8=",
+      "requires": {
+        "jws": "^3.1.4",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -7479,15 +6684,8 @@
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
         "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
+        "ms": "^2.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "jsprim": {
@@ -7520,11 +6718,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "key-tree-store": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/key-tree-store/-/key-tree-store-1.3.0.tgz",
-      "integrity": "sha1-XqKa/CUppCWThDfWlVtxTOapeR8="
-    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -7533,7 +6726,8 @@
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true
     },
     "knex": {
       "version": "0.19.5",
@@ -7606,14 +6800,6 @@
         "package-json": "^4.0.0"
       }
     },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "^1.0.0"
-      }
-    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7645,65 +6831,6 @@
         "resolve": "^1.1.7"
       }
     },
-    "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
-      }
-    },
-    "localtunnel": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.2.tgz",
-      "integrity": "sha512-NEKF7bDJE9U3xzJu3kbayF0WTvng6Pww7tzqNb/XtEARYwqw7CKEX7BvOMg98FtE9es2CRizl61gkV3hS8dqYg==",
-      "requires": {
-        "axios": "0.19.0",
-        "debug": "4.1.1",
-        "openurl": "1.1.1",
-        "yargs": "6.6.0"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.19.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-          "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
-          "requires": {
-            "follow-redirects": "1.5.10",
-            "is-buffer": "^2.0.2"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -7727,129 +6854,25 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "lodash-decorators": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash-decorators/-/lodash-decorators-4.5.0.tgz",
-      "integrity": "sha512-isfVBBSzzXu7Z6abY/Bit5hCbM+gPhQx/DluTPAmzUPF3KRtvLLRNBgVFUxw6B8vwTMGyQFRVqbvQBli9hsXZA==",
-      "requires": {
-        "tslib": "^1.7.1"
-      }
-    },
-    "lodash._arraycopy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
-    },
-    "lodash._arrayeach": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
-    },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._baseclone": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
-      "requires": {
-        "lodash._arraycopy": "^3.0.0",
-        "lodash._arrayeach": "^3.0.0",
-        "lodash._baseassign": "^3.0.0",
-        "lodash._basefor": "^3.0.0",
-        "lodash.isarray": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-    },
-    "lodash._basefor": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
-    },
-    "lodash._bindcallback": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-    },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-    },
-    "lodash.clone": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
-      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
-    },
-    "lodash.clonedeep": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
-      "requires": {
-        "lodash._baseclone": "^3.0.0",
-        "lodash._bindcallback": "^3.0.0"
-      }
-    },
-    "lodash.fill": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.fill/-/lodash.fill-3.4.0.tgz",
-      "integrity": "sha1-o8dK5kDQU63w3CB5+HIHiOi/74U="
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
     },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
-    "lodash.intersection": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
-      "integrity": "sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU="
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-    },
     "lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
@@ -7871,61 +6894,35 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
+    "lodash.last": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
+      "integrity": "sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw="
     },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    "lodash.max": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
+      "integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
     },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
-    "lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
-    },
-    "lodash.partialright": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lodash.partialright/-/lodash.partialright-4.2.1.tgz",
-      "integrity": "sha1-ATDYDoM2MmTUAHTzKbij56ihzEs="
-    },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
-    "lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    "lodash.tonumber": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
+      "integrity": "sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk="
     },
-    "long": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+    "lodash.trimend": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
+      "integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -7941,30 +6938,6 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
-    },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "ltx": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.9.2.tgz",
-      "integrity": "sha512-llB7HflFhlfsYYT1SAe80elCBO5C20ryLdwPB/A/BZk38hhVeZztDlWQ9uTyvKNPX4aK6sA+JfS1f/mfzp5cxA==",
-      "requires": {
-        "inherits": "^2.0.4"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        }
-      }
     },
     "make-dir": {
       "version": "1.3.0",
@@ -8011,26 +6984,6 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
-      }
-    },
-    "md5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
-      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
-      "requires": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
-      }
-    },
-    "md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
       }
     },
     "media-typer": {
@@ -8098,19 +7051,10 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -8146,11 +7090,6 @@
       "requires": {
         "minimist": "0.0.8"
       }
-    },
-    "moment": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
     },
     "ms": {
       "version": "2.0.0",
@@ -8207,8 +7146,7 @@
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-      "dev": true
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -8227,72 +7165,11 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
-    "node-forge": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
-    },
-    "node-jose": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-0.11.1.tgz",
-      "integrity": "sha512-1mX5prmancKdOgMI/85uduqWNFg63traxVdun7dNNsX4AUs6HqztJhzfBlIWfSujQ8Rah9dWLGUFlXORxZvvzg==",
-      "requires": {
-        "b64u": "^2.0.0",
-        "es6-promise": "^4.0.5",
-        "lodash.assign": "^4.0.8",
-        "lodash.clone": "^4.3.2",
-        "lodash.fill": "^3.2.2",
-        "lodash.flatten": "^4.2.0",
-        "lodash.intersection": "^4.1.2",
-        "lodash.merge": "^4.3.5",
-        "lodash.omit": "^4.2.1",
-        "lodash.partialright": "^4.1.3",
-        "lodash.pick": "^4.2.0",
-        "lodash.uniq": "^4.2.1",
-        "long": "^3.1.0",
-        "node-forge": "^0.7.1",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node-kms": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/node-kms/-/node-kms-0.3.2.tgz",
-      "integrity": "sha1-beflJICO7ATHf+6072SUDlDit1k=",
-      "requires": {
-        "es6-promise": "^2.0.1",
-        "lodash.clone": "^3.0.2",
-        "lodash.clonedeep": "^3.0.1",
-        "node-jose": ">=0.3.0 <1.0",
-        "uuid": "^2.0.1"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-          "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
-        },
-        "lodash.clone": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
-          "integrity": "sha1-hGiMc9MrWpDKJWFpY/GJJSqZcEM=",
-          "requires": {
-            "lodash._baseclone": "^3.0.0",
-            "lodash._bindcallback": "^3.0.0",
-            "lodash._isiterateecall": "^3.0.0"
-          }
-        },
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
-        }
-      }
     },
     "node-modules-regexp": {
       "version": "1.0.0",
@@ -8312,83 +7189,6 @@
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
       }
-    },
-    "node-scr": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/node-scr/-/node-scr-0.2.2.tgz",
-      "integrity": "sha1-VCqtdCAQ0S5Bm1kG2lFq+d6jBdo=",
-      "requires": {
-        "es6-promise": "^2.0.1",
-        "lodash.clone": "^3.0.2",
-        "node-jose": ">=0.3.0 <1.0"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-          "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
-        },
-        "lodash.clone": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
-          "integrity": "sha1-hGiMc9MrWpDKJWFpY/GJJSqZcEM=",
-          "requires": {
-            "lodash._baseclone": "^3.0.0",
-            "lodash._bindcallback": "^3.0.0",
-            "lodash._isiterateecall": "^3.0.0"
-          }
-        }
-      }
-    },
-    "node-xmpp-client": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/node-xmpp-client/-/node-xmpp-client-3.2.0.tgz",
-      "integrity": "sha1-r0Un3wzFq9JpDLohOcwezcgeoYk=",
-      "requires": {
-        "browser-request": "^0.3.3",
-        "debug": "^2.2.0",
-        "md5.js": "^1.3.3",
-        "minimist": "^1.2.0",
-        "node-xmpp-core": "^5.0.9",
-        "request": "^2.65.0",
-        "ws": "^1.1.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "ws": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-          "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
-          "requires": {
-            "options": ">=0.0.5",
-            "ultron": "1.0.x"
-          }
-        }
-      }
-    },
-    "node-xmpp-core": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/node-xmpp-core/-/node-xmpp-core-5.0.9.tgz",
-      "integrity": "sha1-XCjCjtsfs/i+uixnYHd2E/SPNCo=",
-      "requires": {
-        "@xmpp/jid": "^0.0.2",
-        "@xmpp/streamparser": "^0.0.6",
-        "@xmpp/xml": "^0.1.3",
-        "debug": "^2.2.0",
-        "inherits": "^2.0.1",
-        "lodash.assign": "^4.0.0",
-        "node-xmpp-tls-connect": "^1.0.1",
-        "reconnect-core": "https://github.com/dodo/reconnect-core/tarball/merged"
-      }
-    },
-    "node-xmpp-tls-connect": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/node-xmpp-tls-connect/-/node-xmpp-tls-connect-1.0.1.tgz",
-      "integrity": "sha1-kazkOsJrE4hhsr5HjfnfGdYdxcM="
     },
     "nodemon": {
       "version": "1.19.1",
@@ -8438,6 +7238,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -8463,11 +7264,6 @@
         "path-key": "^2.0.0"
       }
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-    },
     "nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -8478,6 +7274,11 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -8535,7 +7336,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.5.1"
@@ -8592,7 +7392,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -8606,16 +7405,10 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "openurl": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
-      "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c="
-    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -8624,8 +7417,7 @@
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         }
       }
     },
@@ -8641,19 +7433,6 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
         "wordwrap": "~1.0.0"
-      }
-    },
-    "options": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "^1.0.0"
       }
     },
     "os-tmpdir": {
@@ -8690,6 +7469,20 @@
       "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
+      }
+    },
+    "p-queue": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
+      "integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng=="
+    },
+    "p-retry": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
+      "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+      "requires": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
       }
     },
     "p-try": {
@@ -8734,19 +7527,11 @@
         "path-root": "^0.1.1"
       }
     },
-    "parse-headers": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.2.tgz",
-      "integrity": "sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==",
-      "requires": {
-        "for-each": "^0.3.3",
-        "string.prototype.trim": "^1.1.2"
-      }
-    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
       }
@@ -8772,25 +7557,25 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
-    "path-exists": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "requires": {
-        "pinkie-promise": "^2.0.0"
-      }
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -8826,23 +7611,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-    },
-    "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
-      }
     },
     "performance-now": {
       "version": "2.1.0",
@@ -8914,20 +7682,8 @@
     "pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true
     },
     "pirates": {
       "version": "4.0.1",
@@ -8964,11 +7720,6 @@
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
-    "pop-iterate": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",
-      "integrity": "sha1-zqz9q0q/NT16DyqqLB/Hs/lBO6M="
-    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -8996,11 +7747,6 @@
       "requires": {
         "xtend": "^4.0.0"
       }
-    },
-    "precond": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -9075,23 +7821,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
-    "prompts": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-1.2.1.tgz",
-      "integrity": "sha512-GE33SMMVO1ISfnq3i6cE+WYK/tLxRWtZiRkl5vdg0KR0owOCPFOsq8BuFajFbW7b2bMHb8krXaQHOpZyUEuvmA==",
-      "requires": {
-        "kleur": "^3.0.0",
-        "sisteransi": "^1.0.0"
-      }
-    },
     "proxy-addr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -9104,7 +7833,8 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "psl": {
       "version": "1.1.31",
@@ -9133,19 +7863,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
-      "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
-      "requires": {
-        "asap": "^2.0.0",
-        "pop-iterate": "^1.0.1",
-        "weak-map": "^1.0.5"
-      }
-    },
-    "qbox": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/qbox/-/qbox-0.1.7.tgz",
-      "integrity": "sha1-6A8NxdCfhp2IghaMP2asjdKEDwI="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
+      "integrity": "sha1-EYcq7t7okmgRCxCnGESP+xARKhQ="
     },
     "qs": {
       "version": "6.5.2",
@@ -9193,36 +7913,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
       "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==",
       "dev": true
-    },
-    "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
-      }
-    },
-    "readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
     },
     "readdirp": {
       "version": "2.2.1",
@@ -9283,30 +7973,6 @@
       "requires": {
         "resolve": "^1.1.6"
       }
-    },
-    "reconnect-core": {
-      "version": "https://github.com/dodo/reconnect-core/tarball/merged",
-      "integrity": "sha512-wZK/v5ZaNaSUs2Wnwh2YSX/Jqv6bQHKNEwojdzV11tByKziR9ikOssf5tvUhx+8/oCBz6AakOFAjZuqPoiRHJQ==",
-      "requires": {
-        "backoff": "~2.3.0"
-      },
-      "dependencies": {
-        "backoff": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
-          "integrity": "sha1-7nx+OAk/kuRyhZ22NedlJFT8Ieo="
-        }
-      }
-    },
-    "reduce-flatten": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
-    },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -9385,6 +8051,14 @@
         "uuid": "^3.3.2"
       }
     },
+    "request-progress": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+      "integrity": "sha1-ByHBBdipasayzossia4tXs/Pazo=",
+      "requires": {
+        "throttleit": "~0.0.2"
+      }
+    },
     "request-promise-core": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
@@ -9405,25 +8079,11 @@
         "tough-cookie": "^2.3.3"
       }
     },
-    "requestretry": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-3.1.0.tgz",
-      "integrity": "sha512-DkvCPK6qvwxIuVA5TRCvi626WHC2rWjF/n7SCQvVHAr2JX9i1/cmIpSEZlmHAo+c1bj9rjaKoZ9IsKwCpTkoXA==",
-      "requires": {
-        "extend": "^3.0.2",
-        "lodash": "^4.17.10",
-        "when": "^3.7.7"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "resolve": {
       "version": "1.10.0",
@@ -9485,10 +8145,10 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
-    "retry-axios": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.2.tgz",
-      "integrity": "sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ=="
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "rimraf": {
       "version": "2.6.3",
@@ -9498,11 +8158,6 @@
       "requires": {
         "glob": "^7.1.3"
       }
-    },
-    "rootpath": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/rootpath/-/rootpath-0.1.2.tgz",
-      "integrity": "sha1-Wzeah9ypBum5HWkKWZQ5vvJn6ms="
     },
     "rsa-pem-from-mod-exp": {
       "version": "0.8.4",
@@ -9514,14 +8169,6 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
-    },
-    "rtcpeerconnection-shim": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz",
-      "integrity": "sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==",
-      "requires": {
-        "sdp": "^2.6.0"
-      }
     },
     "run-async": {
       "version": "2.3.0",
@@ -9621,6 +8268,11 @@
         }
       }
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "saxes": {
       "version": "3.1.11",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
@@ -9630,25 +8282,11 @@
         "xmlchars": "^2.1.1"
       }
     },
-    "scmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.0.0.tgz",
-      "integrity": "sha1-JHEQ7yLM+JexOj8KvdtSeCOTzWo="
-    },
-    "sdp": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.10.0.tgz",
-      "integrity": "sha512-H+VjfyQpRz9GezhshJmkXTtCAT9/2g9az3GFDPYfGOz0eAOQU1fCrL3S9Dq/eUT9FtOyLi/czdR9PzK3fKUYOQ=="
-    },
-    "sdp-transform": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.13.0.tgz",
-      "integrity": "sha512-3zT7pcjR090E0WCV9eOtFX06iojoNKsyMXqXs7clOs8sy+RoegR0cebmCuCrTKdY2jw1XhT9jkraygJrqAUwzA=="
-    },
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -9700,7 +8338,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -9765,19 +8404,11 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
-    "simple-xmpp": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/simple-xmpp/-/simple-xmpp-1.3.1.tgz",
-      "integrity": "sha512-o0wGVlI8Q4o0qTz6Kylbo1QPOMVn+DA/vyHHZecqcQ+LK4ZWGe3wtRON9QjHAkSyxB36PoagmiUz4pHADau8Mw==",
-      "requires": {
-        "node-xmpp-client": "^3.0.0",
-        "qbox": "0.1.x"
-      }
-    },
     "sisteransi": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
-      "integrity": "sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg=="
+      "integrity": "sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==",
+      "dev": true
     },
     "slash": {
       "version": "3.0.0",
@@ -9945,6 +8576,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -9953,12 +8585,14 @@
     "spdx-exceptions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -9967,7 +8601,8 @@
     "spdx-license-ids": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
+      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+      "dev": true
     },
     "split": {
       "version": "1.0.1",
@@ -9984,11 +8619,6 @@
       "requires": {
         "extend-shallow": "^3.0.0"
       }
-    },
-    "sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -10069,47 +8699,6 @@
         }
       }
     },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      }
-    },
-    "string.prototype.trim": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.0.tgz",
-      "integrity": "sha512-9EIjYD/WdlvLpn987+ctkLf0FfvBefOCuiEr2henD8X+7jfwPnyvTdmW8OJhj5p+M0/96mBdynLWkxUr+rHlpg==",
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.13.0",
-        "function-bind": "^1.1.1"
-      }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
-    "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "requires": {
-        "is-utf8": "^0.2.0"
-      }
-    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -10128,10 +8717,19 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -10203,33 +8801,6 @@
           "requires": {
             "ansi-regex": "^4.1.0"
           }
-        }
-      }
-    },
-    "table-layout": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz",
-      "integrity": "sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==",
-      "requires": {
-        "array-back": "^2.0.0",
-        "deep-extend": "~0.6.0",
-        "lodash.padend": "^4.6.1",
-        "typical": "^2.6.1",
-        "wordwrapjs": "^3.0.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "requires": {
-            "typical": "^2.6.1"
-          }
-        },
-        "typical": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
         }
       }
     },
@@ -10392,19 +8963,15 @@
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "dev": true
     },
+    "throttleit": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-    },
-    "through2": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-      "requires": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      }
     },
     "tildify": {
       "version": "2.0.0",
@@ -10515,6 +9082,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -10538,30 +9113,6 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
-    "twilio": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.37.0.tgz",
-      "integrity": "sha512-XnuTpDncrTCU3aj07wrgZMt/LIA3zKJ73U4RX+vWdx9J7Ppmxk1z8XxsSmjinNBZW+N4sYPkChoA7s4PV1CqyA==",
-      "requires": {
-        "@types/express": "^4.17.1",
-        "deprecate": "1.0.0",
-        "jsonwebtoken": "^8.5.1",
-        "lodash": "^4.17.15",
-        "moment": "^2.24.0",
-        "q": "2.0.x",
-        "request": "^2.88.0",
-        "rootpath": "0.1.2",
-        "scmp": "2.0.0",
-        "xmlbuilder": "9.0.1"
-      },
-      "dependencies": {
-        "moment": {
-          "version": "2.24.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-          "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
-        }
-      }
     },
     "type-check": {
       "version": "0.3.2",
@@ -10611,16 +9162,10 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
-    },
     "uglify-js": {
       "version": "3.6.7",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.7.tgz",
       "integrity": "sha512-4sXQDzmdnoXiO+xvmTzQsfIiwrjUCSA95rSP4SEd8tDb51W2TiDOlL76Hl+Kw0Ie42PSItCW8/t6pBNCF2R48A==",
-      "dev": true,
       "optional": true,
       "requires": {
         "commander": "~2.20.3",
@@ -10631,15 +9176,9 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
           "optional": true
         }
       }
-    },
-    "ultron": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
     },
     "unc-path-regex": {
       "version": "0.1.2",
@@ -10674,6 +9213,11 @@
       "requires": {
         "crypto-random-string": "^1.0.0"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -10764,11 +9308,6 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
-    "url-join": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-      "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
-    },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -10778,20 +9317,25 @@
         "prepend-http": "^1.0.1"
       }
     },
-    "url-template": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
-    },
-    "urlsafe-base64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
-      "integrity": "sha1-I/iQaabGL0bPOh07ABac77kL4MY="
-    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        }
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -10803,7 +9347,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "object.getownpropertydescriptors": "^2.0.3"
@@ -10831,6 +9374,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -10871,6 +9415,14 @@
         "xml-name-validator": "^3.0.0"
       }
     },
+    "walk": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.14.tgz",
+      "integrity": "sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==",
+      "requires": {
+        "foreachasync": "^3.0.0"
+      }
+    },
     "walker": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
@@ -10888,11 +9440,6 @@
         "wrap-fn": "^0.1.0"
       }
     },
-    "weak-map": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz",
-      "integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes="
-    },
     "weak-napi": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/weak-napi/-/weak-napi-1.0.3.tgz",
@@ -10909,15 +9456,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
-    },
-    "webrtc-adapter": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-6.4.8.tgz",
-      "integrity": "sha512-YM8yl545c/JhYcjGHgaCoA7jRK/KZuMwEDFeP2AcP0Auv5awEd+gZE0hXy9z7Ed3p9HvAXp8jdbe+4ESb1zxAw==",
-      "requires": {
-        "rtcpeerconnection-shim": "^1.2.14",
-        "sdp": "^2.9.0"
-      }
     },
     "whatwg-encoding": {
       "version": "1.0.5",
@@ -10945,11 +9483,6 @@
         "webidl-conversions": "^4.0.2"
       }
     },
-    "when": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
-      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
-    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -10957,11 +9490,6 @@
       "requires": {
         "isexe": "^2.0.0"
       }
-    },
-    "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
     },
     "widest-line": {
       "version": "2.0.1",
@@ -11011,44 +9539,25 @@
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
-    "wordwrapjs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
-      "requires": {
-        "reduce-flatten": "^1.0.1",
-        "typical": "^2.6.1"
-      },
-      "dependencies": {
-        "typical": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
-        }
-      }
-    },
-    "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      }
-    },
     "wrap-fn": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
       "integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
       "requires": {
         "co": "3.1.0"
+      },
+      "dependencies": {
+        "co": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+          "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
+        }
       }
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
@@ -11070,14 +9579,6 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
-    },
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
@@ -11090,10 +9591,20 @@
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
+    "xml2js": {
+      "version": "0.4.22",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.22.tgz",
+      "integrity": "sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "util.promisify": "~1.0.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
     "xmlbuilder": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.1.tgz",
-      "integrity": "sha1-kc1wiXdVNj66V8Et3uq0o0GmH2U="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlchars": {
       "version": "2.2.0",
@@ -11105,44 +9616,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-    },
-    "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "yargs": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-      "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-      "requires": {
-        "camelcase": "^3.0.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.2",
-        "which-module": "^1.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^4.2.0"
-      }
-    },
-    "yargs-parser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-      "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-      "requires": {
-        "camelcase": "^3.0.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "body-parser": "^1.19.0",
-    "botkit": "^0.7.4",
+    "botbuilder-adapter-slack": "^1.0.6",
+    "botkit": "^4.6.1",
     "botkit-storage-pg": "^0.2.2",
     "dotenv": "^6.2.0",
     "express": "^4.17.1",


### PR DESCRIPTION
This PR is about updating `botkit` to the latest version. ([JIRA](https://commoncode.atlassian.net/browse/CCP-194) ticket).

Botkit4 has a different structure, so this is what has been done in this PR:
- Added the required package for the desired `adapter` (for this project it is `botbuilder-adapter-slack`)
- Added options to this adapter --> we are configuring slack for _multi-teams_, so there are a lot of parameters to add. See [here](https://github.com/howdyai/botkit/tree/master/packages/botbuilder-adapter-slack#multi-team-support) for details, but don't forget that because we use `ngrok`, the `REDIRECT_URI` environment variable has to be updated each time you close the connection. (And add this variable to `.env` if you don't have it, it is a required param).
- Instantiate this `adapter` class with the created options.
- Instantiate the `Botkit` core class controller with the adapter, in addition to an internal memory `storage` (see below in DB paragraph for details).

To see if your bot is installed properly:
- `npm run dev` as usual
- `ngrok http 3000` (no changes here)
Then go to the `install` endpoint `http://localhost:3000/install` and you should see your slack app requesting authorisation to continue. If you agree it should redirect you to the `REDIRECT_URI`, and you will see the message : `Success! Bot installed`.

At the moment we are only storing a few oauth tokens in the internal storage. But the next thing to solve is **the DB storage** for skills and users. As said in the docs: _In v4 of Botkit, the storage system is currently only used to store and retrieve the conversation state between turns. Other than this, Botkit will no longer be providing an interface for connecting to or using databases. Developers should build their own database abstractions._

**P.S**: instead of `server.js` we are using `botController.webserver`: it looks like it is recommended to use this express server, which is shipped with the controller.